### PR TITLE
Remove nginx restart from deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,5 +32,4 @@ jobs:
           sudo mv dist /usr/share/nginx/html/demo/
           sudo semanage fcontext -a -t httpd_sys_content_t "/usr/share/nginx/html/demo/dist(/.*)?"
           sudo restorecon -Rv /usr/share/nginx/html/demo/dist
-          sudo systemctl restart nginx
           


### PR DESCRIPTION
Removed the command to restart nginx after deployment.